### PR TITLE
Added grunt release task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,12 +12,32 @@ module.exports = function(grunt) {
           'dist/data-metrics.min.js': 'src/data-metrics.js'
         }
       }
+    },
+
+    // Release task
+    bump: {
+      options: {
+        files: ['package.json', 'bower.json'],
+        updateConfigs: [],
+        commit: true,
+        commitMessage: 'Release v%VERSION%',
+        commitFiles: ['-a'], // '-a' for all files
+        createTag: true,
+        tagName: 'v%VERSION%',
+        tagMessage: 'Version %VERSION%',
+        push: true,
+        pushTo: 'origin master',
+        gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d' // options to use with '$ git describe'
+      }
     }
   });
 
   //Dependencies.
   grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-bump');
 
   //Tasks.
   grunt.registerTask('default', ['uglify']);
+
+  grunt.registerTask('release', ['bump']);
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "devDependencies": {
     "grunt-cli": "~0.1.7",
     "grunt": "~0.4.1",
-    "grunt-contrib-uglify": "~0.2.0"
+    "grunt-contrib-uglify": "~0.2.0",
+    "grunt-bump": "~0.0.x"
   },
   "keywords": []
 }


### PR DESCRIPTION
Added [grunt-bump](https://github.com/vojtajina/grunt-bump) plugin for automating release process.

Just run `grunt release --setversion=0.6.0` to have it updating both _package.json_ and _bower.json_ files, committing and creating a tag on github.

Do not forget to `npm install` to update dependencies before trying it ;)
